### PR TITLE
Changed municipality of Montfoort url to Cyclus

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -26,6 +26,7 @@ Current Version: 2.5.7 20200113 - Pippijn Stortelder
 20191115 - Added Duobak as a fraction
 20200108 - Added Purmerend and an option to disable the entity_picture
 20200113 - Support for ROVA
+20200115 - Changed municipality of Montfoort url to Cyclus
 
 Description:
   Provides sensors for the following Dutch waste collectors;
@@ -138,7 +139,7 @@ COLLECTOR_URL = {
     'gad': 'https://inzamelkalender.gad.nl',
     'hvc': 'https://inzamelkalender.hvcgroep.nl',
     'meerlanden': 'https://afvalkalender.meerlanden.nl',
-    'montfoort': 'https://afvalkalender.montfoort.nl',
+    'montfoort': 'https://afvalkalender.cyclusnv.nl',
     'peelenmaas': 'https://afvalkalender.peelenmaas.nl',
     'purmerend': 'https://afvalkalender.purmerend.nl',
     'rmn': 'https://inzamelschema.rmn.nl',


### PR DESCRIPTION
Looks like the Municipality of Montfoort switched to Cycles: https://afvalkalender.cyclusnv.nl/adres/3417EJ:1

The old site isn't resolving anymore: https://afvalkalender.montfoort.nl/

Or, as an alternative we could completely remove Montfoort from the list and specify cyclus as wastecollector instead:

Configuration.yaml:
```
  sensor:
    - platform: afvalbeheer
      wastecollector: cyclus
```