### PR TITLE
Support for Area Reiniging (Coevorden, Emmen and Hoogeveen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Home Assisant sensor component for Afvalbeheer
 
 Provides Home Assistant sensors for multiple Dutch and Belgium waste collectors using REST API.
-This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, Afval Alert, Ophaalkalender, DeAfvalApp and Alkmaar.
+This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, Afval Alert, Ophaalkalender, DeAfvalApp, Alkmaar and Area Reiniging (Coevorden, Emmen and Hoogeveen).
 
 Cure users should switch to the waste collector MijnAfvalwijzer
 
@@ -44,6 +44,7 @@ Choose your collector from this list:
   - AfvalAlert
   - Alkmaar
   - AlphenAanDenRijn
+  - Area Reiniging
   - Avalex
   - Berkelland
   - Blink
@@ -98,6 +99,7 @@ Some collectors also use some of these options:
   - kca
   - pbd
   - duobak
+  - restwagen
 
 ### Postcode
 Postcode is required and is your own postcode

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Home Assisant sensor component for Afvalbeheer
 
 Provides Home Assistant sensors for multiple Dutch and Belgium waste collectors using REST API.
-This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, Afval Alert, Ophaalkalender, DeAfvalApp, Alkmaar and Area Reiniging (Coevorden, Emmen and Hoogeveen).
+This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, Afval Alert, Ophaalkalender, DeAfvalApp, Alkmaar and Area Reiniging.
 
 Cure users should switch to the waste collector MijnAfvalwijzer
 

--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -20,9 +20,9 @@ Current Version: 4.2.8 20200515 - Pippijn Stortelder
 20200506 - Support for Limburg.NET and AfvalAlert
 20200512 - Fix fraction mapping for Circulus Berkel
 20200513 - Add attribute days_until
-20200514 - Fix raction mapping for MijnAfvalWijzer
-20200515 - Fix raction mapping for Limburg.NET
-20200519 - Fix raction mapping for Circulus-Berkel
+20200514 - Fix fraction mapping for MijnAfvalWijzer
+20200515 - Fix fraction mapping for Limburg.NET
+20200519 - Fix fraction mapping for Circulus-Berkel
 20200523 - Support for Area Reiniging
 
 Example config:

--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -20,9 +20,10 @@ Current Version: 4.2.8 20200515 - Pippijn Stortelder
 20200506 - Support for Limburg.NET and AfvalAlert
 20200512 - Fix fraction mapping for Circulus Berkel
 20200513 - Add attribute days_until
-20200514 - Fix fraction mapping for MijnAfvalWijzer
-20200515 - Fix fraction mapping for Limburg.NET
-20200519 - Fix fraction mapping for Circulus-Berkel
+20200514 - Fix raction mapping for MijnAfvalWijzer
+20200515 - Fix raction mapping for Limburg.NET
+20200519 - Fix raction mapping for Circulus-Berkel
+20200523 - Support for Area Reiniging
 
 Example config:
 Configuration.yaml:
@@ -116,6 +117,7 @@ OPZET_COLLECTOR_URLS = {
 
 XIMMIO_COLLECTOR_IDS = {
     'acv': 'f8e2844a-095e-48f9-9f98-71fceb51d2c3',
+    'area': 'adc418da-d19b-11e5-ab30-625662870761',
     'hellendoorn': '24434f5b-7244-412b-9306-3a2bd1e22bc1',
     'meerlanden': '800bf8d7-6dd1-4490-ba9d-b419d6dc8a45',
     'twentemilieu': '8d97bb56-5afd-4cbc-a651-b4f7314264b4',
@@ -134,6 +136,7 @@ WASTE_TYPE_PAPER_PMD = 'papier-pmd'
 WASTE_TYPE_PACKAGES = 'pmd'
 WASTE_TYPE_PAPER = 'papier'
 WASTE_TYPE_PLASTIC = 'plastic'
+WASTE_TYPE_REMAINDER = 'restwagen'
 WASTE_TYPE_TEXTILE = 'textiel'
 WASTE_TYPE_TREE = 'kerstbomen'
 WASTE_TYPE_BULKYGARDENWASTE = 'tuinafval'
@@ -988,6 +991,7 @@ class XimmioCollector(WasteCollector):
         'KCA': WASTE_TYPE_KCA,
         'PACKAGES': WASTE_TYPE_PACKAGES,
         'PAPER': WASTE_TYPE_PAPER,
+        'REMAINDER': WASTE_TYPE_REMAINDER,
         'TEXTILE': WASTE_TYPE_TEXTILE,
         'TREE': WASTE_TYPE_TREE,
     }

--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -1,7 +1,7 @@
 """
 Sensor component for waste pickup dates from dutch and belgium waste collectors
 Original Author: Pippijn Stortelder
-Current Version: 4.2.8 20200515 - Pippijn Stortelder
+Current Version: 4.2.9 20200523 - Pippijn Stortelder
 20200419 - Major code refactor (credits @basschipper)
 20200420 - Add sensor even though not in mapping
 20200420 - Added support for DeAfvalApp

--- a/info.md
+++ b/info.md
@@ -1,7 +1,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 ## Home Assisant sensor component for Afvalbeheer
 
-Provides Home Assistant sensors for multiple Dutch and Belgium waste collectors using REST API. This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, AfvalAlert, Ophaalkalender, DeAfvalApp, Alkmaar and Area Reiniging (Coevorden, Emmen and Hoogeveen).
+Provides Home Assistant sensors for multiple Dutch and Belgium waste collectors using REST API. This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, AfvalAlert, Ophaalkalender, DeAfvalApp, Alkmaar and Area Reiniging.
 
 Cure users should switch to the waste collector MijnAfvalwijzer
 

--- a/info.md
+++ b/info.md
@@ -1,7 +1,7 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)
 ## Home Assisant sensor component for Afvalbeheer
 
-Provides Home Assistant sensors for multiple Dutch and Belgium waste collectors using REST API. This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, AfvalAlert, Ophaalkalender, DeAfvalApp and Alkmaar.
+Provides Home Assistant sensors for multiple Dutch and Belgium waste collectors using REST API. This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, Limburg.NET, AfvalAlert, Ophaalkalender, DeAfvalApp, Alkmaar and Area Reiniging (Coevorden, Emmen and Hoogeveen).
 
 Cure users should switch to the waste collector MijnAfvalwijzer
 


### PR DESCRIPTION
Hallo Pippijn,

Voor Area Reiniging heb ik in het verleden een integratie gebouwd op mijn github pagina and in HACS gepubliceerd.
Mijn plan was om deze uit te breiden qua functionaliteit, maar zag toen jouw integratie waarbij de Ximmio Collector ook is opgenomen. En je hebt de functionaliteit mooi uitgewerkt.
Area Reiniging maakt van dezelfde Ximmio Collector gebruik, namelijk:
https://area-afval.ximmio.com/modules/adc418da-d19b-11e5-ab30-625662870761/kalender/.
Zal de mijne indien akkoord dan deprecated maken in de toekomst.

Ik heb deze door middel van deze pull request toegevoegd.
Deze versie heb ik momenteel lokaal draaien en werkt voor restafval, gft, restwagen en plastic.
(Hierbij worden door Area Reiniging  papier, textiel en kerstbomen ook ondersteund, maar heb deze niet kunnen testen. Echter past de Ximmio Collector deze wel correct toe zag ik.)
Verder heb ik de restwagen toegvoegd, aangezien deze nog niet voorkwam in de lijst.

Als er vragen of opmerkingen zijn hoor ik dat graag.

Met vriendelijke groet,
Hein Oldenhuis