### PR TITLE
Omrin API hang causing sensors to be not available

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -792,7 +792,7 @@ class OmrinCollector(WasteCollector):
         encryptedRequest = pkcs1.encrypt(json.dumps(requestBody).encode(), rsaPublicKey)
         base64EncodedRequest = b64encode(encryptedRequest).decode("utf-8")
 
-        response = requests.post("{}/FetchAccount/".format(self.main_url) + self.appId, '"' + base64EncodedRequest + '"').json()
+        response = requests.post("{}/FetchAccount/".format(self.main_url) + self.appId, '"' + base64EncodedRequest + '"', timeout=60).json()
         return response['CalendarHomeV2']
 
     async def update(self):

--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -798,13 +798,12 @@ class OmrinCollector(WasteCollector):
     async def update(self):
         _LOGGER.debug('Updating Waste collection dates using Rest API')
 
-        self.collections.remove_all()
-
         try:
             if not self.publicKey:
                 await self.hass.async_add_executor_job(self.__fetch_publickey)
 
             response = await self.hass.async_add_executor_job(self.__get_data)
+            self.collections.remove_all()
             for item in response:
                 if not item['Datum']:
                     continue


### PR DESCRIPTION
At random moments in time the Omrin API will hang indefinitely. Adding a timeout of 60 seconds makes sure that it will fail and try again. For this reason the removal of collections has been moved down so it can first attempt to fetch data and then remove the old collections.