### PR TITLE
Proper fix to support timezone offset in omrin collection date

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -874,7 +874,7 @@ class OmrinCollector(WasteCollector):
                     continue
 
                 collection = WasteCollection.create(
-                    date=datetime.strptime(item['Datum'], '%Y-%m-%dT%H:%M:%S+02:00'),
+                    date=datetime.strptime(item['Datum'], '%Y-%m-%dT%H:%M:%S%z').replace(tzinfo=None),
                     waste_type=waste_type
                 )
                 self.collections.add(collection)


### PR DESCRIPTION
Fix applied in commit [Fix Omrin date](https://github.com/pippyn/Home-Assistant-Sensor-Afvalbeheer/commit/e6ad9fae4d7152b29d165679c938c1d04d33c468) does not support DST and will stop working eventually.