### PR TITLE
Enabled textile for RecycleApp

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -1091,7 +1091,7 @@ class RecycleApp(WasteCollector):
         'rest': WASTE_TYPE_GREY,
         # 'plastic': WASTE_TYPE_PACKAGES,
         'papier': WASTE_TYPE_PAPER,
-        # 'textiel': WASTE_TYPE_TEXTILE,
+        'textiel': WASTE_TYPE_TEXTILE,
         # 'kerstb': WASTE_TYPE_TREE,
         'pmd': WASTE_TYPE_PACKAGES,
         'gemengde': WASTE_TYPE_PLASTIC,


### PR DESCRIPTION
Textile is available for RecyleApp as you can see here:

![image](https://user-images.githubusercontent.com/4804496/104784417-81378400-5788-11eb-9e83-3837b109f3eb.png)

The icon is missing, I am not sure where you get the FRACTION_ICONS from?