### PR TITLE
added folies to recycle app

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -1102,7 +1102,8 @@ class RecycleApp(WasteCollector):
         'gemengde': WASTE_TYPE_PLASTIC,
         'snoeihout': WASTE_TYPE_BRANCHES,
         'zachte plastics': WASTE_TYPE_SOFT_PLASTIC,
-        'roze zak': WASTE_TYPE_SOFT_PLASTIC
+        'roze zak': WASTE_TYPE_SOFT_PLASTIC,
+        'folies': WASTE_TYPE_SOFT_PLASTIC
     }
 
     def __init__(self, hass, waste_collector, postcode, street_name, street_number, suffix):


### PR DESCRIPTION
Recycleapp added a new type 'folies' to their API that wasn't mapped.
I've tested this mapping and was able to retrieve the folies value:
![image](https://user-images.githubusercontent.com/51802836/105911422-769fa900-602a-11eb-9f13-f8f04bad4689.png)
