### PR TITLE
Replace main_url in XimmioCollector to wasteprod2api.ximmio.com

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -1293,7 +1293,7 @@ class XimmioCollector(WasteCollector):
 
     def __init__(self, hass, waste_collector, postcode, street_number, suffix, address_id):
         super(XimmioCollector, self).__init__(hass, waste_collector, postcode, street_number, suffix)
-        self.main_url = "https://wasteapi.ximmio.com"
+        self.main_url = "https://wasteprod2api.ximmio.com"
         self.company_code = XIMMIO_COLLECTOR_IDS[self.waste_collector]
         self.community = ""
         if address_id:

--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -1291,9 +1291,16 @@ class XimmioCollector(WasteCollector):
         'TREE': WASTE_TYPE_TREE,
     }
 
+    XIMMIO_URLS = {
+        'meerlanden': "https://wasteprod2api.ximmio.com"
+    }
+
     def __init__(self, hass, waste_collector, postcode, street_number, suffix, address_id):
         super(XimmioCollector, self).__init__(hass, waste_collector, postcode, street_number, suffix)
-        self.main_url = "https://wasteprod2api.ximmio.com"
+        if self.waste_collector in self.XIMMIO_URLS.keys():
+            self.main_url = self.XIMMIO_URLS[self.waste_collector]
+        else:
+            self.main_url = "https://wasteapi.ximmio.com"
         self.company_code = XIMMIO_COLLECTOR_IDS[self.waste_collector]
         self.community = ""
         if address_id:


### PR DESCRIPTION
fixes #193 

The old endpoint seems to be broken. This url is being used by https://inzamelkalender.meerlanden.nl/modules/800bf8d7-6dd1-4490-ba9d-b419d6dc8a45/kalender/ and gives the correct response for `api/FetchAdress` as well.

**note:** I also tested this by changing the file locally on my homeassistant installation and that works as well. I only tested this for Meerlanden. Since there are no tests, it might be worth it to double check if this doesn't break other ximmio collectors?