### PR TITLE
Removed capital letters & "-" to improve UI

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -86,10 +86,10 @@ CONF_ALWAYS_SHOW_DAY = 'alwaysshowday'
 CONF_PRINT_AVAILABLE_WASTE_TYPES = 'printwastetypes'
 CONF_UPDATE_INTERVAL = 'updateinterval'
 
-ATTR_WASTE_COLLECTOR = 'Wastecollector'
-ATTR_HIDDEN = 'Hidden'
-ATTR_SORT_DATE = 'Sort-date'
-ATTR_DAYS_UNTIL = 'Days-until'
+ATTR_WASTE_COLLECTOR = 'wastecollector'
+ATTR_HIDDEN = 'hidden'
+ATTR_SORT_DATE = 'sortdate'
+ATTR_DAYS_UNTIL = 'daysuntil'
 
 NOTIFICATION_ID = "Afvalbeheer"
 


### PR DESCRIPTION
I wanted to improve my UI more, so I needed to use JavaScript. But I was not able to retrieve the state of an atribute like this: states['sensor.recycleapp_XXXX_gft'].attributes.Days-until  Removing the capital letters and "-" did the trick.