### PR TITLE
Add source waste term for WASTE_TYPE_PAPER used by Avalex

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -912,6 +912,7 @@ class OpzetCollector(WasteCollector):
         'rest': WASTE_TYPE_GREY,
         'plastic': WASTE_TYPE_PACKAGES,
         'papier': WASTE_TYPE_PAPER,
+        'papier en karton': WASTE_TYPE_PAPER,
         'textiel': WASTE_TYPE_TEXTILE,
         'kerstb': WASTE_TYPE_TREE,
         'pmd': WASTE_TYPE_PACKAGES,


### PR DESCRIPTION
The list of titles of returned items for my home address is this:
```
>>> r = requests.get('https://www.avalex.nl/rest/adressen/<anonimized>/afvalstromen').json()
>>> [d['menu_title'] for d in r if d['ophaaldatum']]
['GFT', 'Papier en karton', 'Restafval']
```