### PR TITLE
Add 'Voorschoten' to OPZET_COLLECTOR_URLS

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -134,6 +134,7 @@ OPZET_COLLECTOR_URLS = {
     'sudwestfryslan': 'https://afvalkalender.sudwestfryslan.nl',
     'suez': 'https://inzamelwijzer.prezero.nl',
     'venray': 'https://afvalkalender.venray.nl',
+    'voorschoten': 'https://afvalkalender.voorschoten.nl',
     'waalre': 'https://afvalkalender.waalre.nl',
     'zrd': 'https://afvalkalender.zrd.nl',
 }


### PR DESCRIPTION
Voorschoten uses the same rest API as the rest of the afvalkalender.* cities