### PR TITLE
Circulus-Berkel URL change (#278)

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -643,7 +643,7 @@ class CirculusBerkelCollector(WasteCollector):
 
     def __init__(self, hass, waste_collector, postcode, street_number, suffix):
         super(CirculusBerkelCollector, self).__init__(hass, waste_collector, postcode, street_number, suffix)
-        self.main_url = "https://mijn.circulus-berkel.nl"
+        self.main_url = "https://mijn.circulus.nl"
 
     def __get_data(self):
         r = requests.get(self.main_url)


### PR DESCRIPTION
Fix for #278.
Updating the waste collector Circukus-Berkel to Circulus would be breaking, so for now just an URL update to make things work again.