### PR TITLE
Make days-until handling timezone-aware

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -876,7 +876,7 @@ class LimburgNetCollector(WasteCollector):
                     continue
 
                 collection = WasteCollection.create(
-                    date=datetime.strptime(item['date'], '%Y-%m-%dT%H:%M:%S%z').replace(tzinfo=None),
+                    date=datetime.fromisoformat(item['date']),
                     waste_type=waste_type
                 )
                 self.collections.add(collection)
@@ -1417,7 +1417,7 @@ class WasteTypeSensor(Entity):
         self.__set_picture(collection)
 
     def __set_state(self, collection):
-        date_diff = (collection.date - datetime.now()).days + 1
+        date_diff = (collection.date - dt_util.utcnow()).days + 1
         self._days_until = date_diff
         date_format = self.date_format
         if self.date_object:


### PR DESCRIPTION
Following discussion in #281

Issue for me is that the "days until" for the limburg.net integration is rendered one day too late in the future.

Regarding my home assistant install timing setup:
* host system was on GMT -- now CET (Brussels time)
* container has a timezone of `Europe/Brussels`, but this was not used.

After reading [home assistant UTC & time zone awareness](https://www.home-assistant.io/blog/2015/05/09/utc-time-zone-awareness/), it seems home assistant was already using UTC internally for quite some time (2015).

I think the proper fix thus is that all you'd use UTC time internally for all time computations, but render to local time where facing the outside world.

I have no idea though how this change will affect the other integrations, I suppose these all also have been assuming no timezone awareness.

On a practical note though, I suppose all of these integrations are either Dutch or Belgian? Perhaps it would just make sense to convert everything to that timezone instead?
