### PR TITLE
Added 'PBD/Papier' and 'PBD' waste types to OpzetCollector

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -960,6 +960,7 @@ class OmrinCollector(WasteCollector):
 
 class OpzetCollector(WasteCollector):
     WASTE_TYPE_MAPPING = {
+        'pbd/papier': WASTE_TYPE_PAPER_PMD,
         'snoeiafval': WASTE_TYPE_BRANCHES,
         'sloop': WASTE_TYPE_BULKLITTER,
         'glas': WASTE_TYPE_GLASS,
@@ -976,6 +977,7 @@ class OpzetCollector(WasteCollector):
         'textiel': WASTE_TYPE_TEXTILE,
         'kerstb': WASTE_TYPE_TREE,
         'pmd': WASTE_TYPE_PACKAGES,
+        'pbd': WASTE_TYPE_PACKAGES,
     }
 
     def __init__(self, hass, waste_collector, postcode, street_number, suffix):


### PR DESCRIPTION
In my region the name "duobak" was changed to "duocontainer". Also PMD was changed to PBD. This broke the integration for me.

I added two waste types ('pbd' and 'pbd/papier') to match this new scheme.
The `PBD/Papier` waste type was added above any other waste type to ensure it matches first (before either PBD or Papier) since it's more specific. 

If the menu_title would only be `papier` it won't match `PBD/Papier` for example so it shouldn't break anything for anyone.