### PR TITLE
Add additonal waste type mapping

### DIFF
--- a/custom_components/afvalbeheer/API.py
+++ b/custom_components/afvalbeheer/API.py
@@ -634,6 +634,7 @@ class OpzetCollector(WasteCollector):
         'kerstb': WASTE_TYPE_TREE,
         'pmd': WASTE_TYPE_PACKAGES,
         'pbd': WASTE_TYPE_PACKAGES,
+        'duocontainer pbd/papier': WASTE_TYPE_PAPER_PMD,
     }
 
     def __init__(self, hass, waste_collector, postcode, street_number, suffix):


### PR DESCRIPTION
When you look at the output of spaarnelanden.nl API you will notice they use different title for the "duocontainer" known within the WASTE_TYPE_MAPPING of OpzetCollector

example request (took random id):
https://afvalwijzer.spaarnelanden.nl/rest/adressen/0392200000098960/afvalstromen