### PR TITLE
Change device class of dateobject sensor

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -92,8 +92,8 @@ class WasteTypeSensor(RestoreEntity, SensorEntity):
 
     @property
     def device_class(self):
-        if self.date_object == True:
-            return SensorDeviceClass.TIMESTAMP
+        if self.date_object:
+            return SensorDeviceClass.DATE
 
     async def async_added_to_hass(self):
         """Call when entity is about to be added to Home Assistant."""
@@ -130,7 +130,7 @@ class WasteTypeSensor(RestoreEntity, SensorEntity):
         self._days_until = date_diff
         date_format = self.date_format
         if self.date_object:
-            self._state = collection.date
+            self._state = collection.date.date
         elif self.date_only or (date_diff >= 8 and not self.always_show_day):
             self._state = collection.date.strftime(date_format)
         elif date_diff > 1:


### PR DESCRIPTION
It seems to be more fitting to present a date object with appropriate device class, as all timestamps are dates anyway, and the setting is also named 'dateobject', not 'datetimeobject'.