### PR TITLE
Added support for 'De Fryske Marren' using Opzet collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Home Assisant sensor component for Afvalbeheer
 
 Provides Home Assistant sensors for multiple Dutch and Belgium waste collectors using REST API.
-This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Schouwen-Duiveland, Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, RWM, Limburg.NET, Afval Alert, RecycleApp, DeAfvalApp, Alkmaar, AreaReiniging, Almere, Waardlanden, Reinis, Avri, Omrin, BAR, Assen, RAD, Meppel, Montferland, PreZero, Lingewaard Voorschoten, Westland, Ôffalkalinder, Afval3xBeter and Middelburg-Vlissingen.
+This sensor works with the following waste collectors: Blink, Cure, Suez, ACV, Twente Milieu, Hellendoorn, Cyclus, DAR, De Fryske Marren, HVC Groep, Meerlanden, RMN (Reinigingsbedrijf Midden Nederland), Schouwen-Duiveland, Peel en Maas, Purmerend, Circulus-Berkel (Afvalvrij), Avalex, Venray, Den Haag, Berkelland, Alphen aan den Rijn, Waalre, ZRD, Spaarnelanden, SudwestFryslan, Montfoort, GAD, Cranendonck, ROVA, RD4, RWM, Limburg.NET, Afval Alert, RecycleApp, DeAfvalApp, Alkmaar, AreaReiniging, Almere, Waardlanden, Reinis, Avri, Omrin, BAR, Assen, RAD, Meppel, Montferland, PreZero, Lingewaard Voorschoten, Westland, Ôffalkalinder, Afval3xBeter and Middelburg-Vlissingen.
 
 Cure users should switch to the waste collector MijnAfvalwijzer
 
@@ -84,6 +84,7 @@ Choose your collector from this list:
   - Cyclus
   - DAR
   - DeAfvalApp
+  - DeFryskeMarren
   - DenHaag
   - GAD
   - Hellendoorn

--- a/custom_components/afvalbeheer/const.py
+++ b/custom_components/afvalbeheer/const.py
@@ -79,6 +79,7 @@ OPZET_COLLECTOR_URLS = {
     'cranendonck':              'https://afvalkalender.cranendonck.nl',
     'cyclus':                   'https://afvalkalender.cyclusnv.nl',
     'dar':                      'https://afvalkalender.dar.nl',
+    'defryskemarren':           'https://afvalkalender.defryskemarren.nl',
     'denhaag':                  'https://huisvuilkalender.denhaag.nl',
     'gad':                      'https://inzamelkalender.gad.nl',
     'hvc':                      'https://inzamelkalender.hvcgroep.nl',

--- a/info.md
+++ b/info.md
@@ -23,6 +23,7 @@ This sensor works with the following waste collectors:
   - Cure (use MijnAfvalwijzer)
   - Cyclus
   - DAR
+  - DeFryskeMarren
   - DeAfvalApp
   - DenHaag
   - GAD


### PR DESCRIPTION
## Description
This PR introduces the Garbage collection calendar from 'De Fryske Marren', which uses the Opzet Collection API.

## Screenshots
### Supported Types
![supported types](https://github.com/pippyn/Home-Assistant-Sensor-Afvalbeheer/assets/4124579/86c33c0a-9edc-4ee2-a370-4bd4c656ba14)
### Working Sensor
![image](https://github.com/pippyn/Home-Assistant-Sensor-Afvalbeheer/assets/4124579/1b8fd097-980e-40d0-af6e-99184c31fba2)

## Source website
See https://afvalkalender.defryskemarren.nl. It's using the Opzet Collection API already supported by this integration.