### PR TITLE
Digitaldotsnl patch 1

### DIFF
--- a/custom_components/afvalbeheer/API.py
+++ b/custom_components/afvalbeheer/API.py
@@ -787,6 +787,8 @@ class OmrinCollector(WasteCollector):
         'Chemisch afval': WASTE_TYPE_KCA,
         'Sortibak': WASTE_TYPE_SORTI,
         'Papier': WASTE_TYPE_PAPER,
+        'Groene container': WASTE_TYPE_GREEN,
+        'Grijze container': WASTE_TYPE_GREY,
         # 'REMAINDER': WASTE_TYPE_REMAINDER,
         # 'TEXTILE': WASTE_TYPE_TEXTILE,
         # 'TREE': WASTE_TYPE_TREE,

--- a/custom_components/afvalbeheer/API.py
+++ b/custom_components/afvalbeheer/API.py
@@ -787,8 +787,6 @@ class OmrinCollector(WasteCollector):
         'Chemisch afval': WASTE_TYPE_KCA,
         'Sortibak': WASTE_TYPE_SORTI,
         'Papier': WASTE_TYPE_PAPER,
-        'Groene container': WASTE_TYPE_GREEN,
-        'Grijze container': WASTE_TYPE_GREY,
         # 'REMAINDER': WASTE_TYPE_REMAINDER,
         # 'TEXTILE': WASTE_TYPE_TEXTILE,
         # 'TREE': WASTE_TYPE_TREE,


### PR DESCRIPTION
Afvalbeheer did not return any data for my Omrin setup. Added two new waste types to OmrinCollector, according to what the printwastetypes message returned for my address (groene container and grijze container). Works after adding these and reloading the config.