### PR TITLE
fix: fixed Twente Milieu wastecollector name

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Choose your collector from this list:
   - Sliedrecht
   - Spaarnelanden
   - SudwestFryslan
-  - Twente Milieu
+  - TwenteMilieu
   - Venray
   - Voorschoten
   - Waalre


### PR DESCRIPTION
The readme  was referring to "Twente Milieu" as the wastecollector name, this was incorrect. It should be TwenteMilieu (or all lowercase)