### PR TITLE
Fixed straatbeeld packages waste type mapping

### DIFF
--- a/custom_components/afvalbeheer/collectors/individual/straatbeeld.py
+++ b/custom_components/afvalbeheer/collectors/individual/straatbeeld.py
@@ -23,6 +23,7 @@ class StraatbeeldCollector(WasteCollector):
         'gft': WASTE_TYPE_GREEN,
         'rest': WASTE_TYPE_GREY,
         'pbd': WASTE_TYPE_PACKAGES,
+        'pmd': WASTE_TYPE_PACKAGES,
         'papier': WASTE_TYPE_PAPER,
         'kerstboom': WASTE_TYPE_TREE,
     }


### PR DESCRIPTION
Out of nowhere, the packages waste type name suddenly changed from pmd to pbd.

Test postal code: `4844CA` `23`

```sh
curl -X POST 'https://drimmelen.api.straatbeeld.online/v1/waste-calendar' \
  -H 'accept: application/json' \
  -H "Content-Type: application/json" \
  -d '{"postal_code":"4844CA","house_number":"23","house_letter":""}'
```