### PR TITLE
Add support for Afvalhulp

### DIFF
--- a/custom_components/afvalbeheer/API.py
+++ b/custom_components/afvalbeheer/API.py
@@ -8,8 +8,8 @@ from homeassistant.components import persistent_notification
 from .const import *
 from .models import WasteCollectionRepository
 from .collectors import (
-    XimmioCollector, BurgerportaalCollector, OpzetCollector, KlikogroepCollector,
-    AfvalAlertCollector, AfvalwijzerCollector, AmsterdamCollector, CirculusCollector, CleanprofsCollector,
+    XimmioCollector, BurgerportaalCollector, OpzetCollector, KlikogroepCollector, AfvalAlertCollector,
+    AfvalhulpCollector, AfvalwijzerCollector, AmsterdamCollector, CirculusCollector, CleanprofsCollector,
     DeAfvalAppCollector, LimburgNetCollector, IradoCollector, MontferlandNetCollector, OmrinCollector,
     RD4Collector, RecycleApp, ReinisCollector, ROVACollector, StraatbeeldCollector
 )
@@ -49,6 +49,7 @@ class WasteData(object):
             "mijnafvalwijzer": (AfvalwijzerCollector, common_args),
             # "afvalstoffendienstkalender": (AfvalwijzerCollector, common_args),
             "afvalalert": (AfvalAlertCollector, common_args),
+            "afvalhulp": (AfvalhulpCollector, common_args),
             "amsterdam": (AmsterdamCollector, common_args),
             "deafvalapp": (DeAfvalAppCollector, common_args),
             "circulus": (CirculusCollector, common_args),

--- a/custom_components/afvalbeheer/collectors/__init__.py
+++ b/custom_components/afvalbeheer/collectors/__init__.py
@@ -4,15 +4,15 @@ Waste collectors for different APIs.
 from .base import WasteCollector
 from .shared import XimmioCollector, BurgerportaalCollector, OpzetCollector, KlikogroepCollector
 from .individual import (
-    AfvalAlertCollector, AfvalwijzerCollector, AmsterdamCollector, CirculusCollector, CleanprofsCollector,
+    AfvalAlertCollector, AfvalhulpCollector, AfvalwijzerCollector, AmsterdamCollector, CirculusCollector, CleanprofsCollector,
     DeAfvalAppCollector, LimburgNetCollector, IradoCollector, MontferlandNetCollector, OmrinCollector,
     RD4Collector, RecycleApp, ReinisCollector, ROVACollector, StraatbeeldCollector
 )
 
 __all__ = [
     "WasteCollector",
-    "XimmioCollector", "BurgerportaalCollector", "OpzetCollector", "KlikogroepCollector",
-    "AfvalAlertCollector", "AfvalwijzerCollector", "AmsterdamCollector", "CirculusCollector", "CleanprofsCollector",
+    "XimmioCollector", "BurgerportaalCollector", "OpzetCollector", "KlikogroepCollector", "AfvalAlertCollector",
+    "AfvalhulpCollector", "AfvalwijzerCollector", "AmsterdamCollector", "CirculusCollector", "CleanprofsCollector",
     "DeAfvalAppCollector", "LimburgNetCollector", "IradoCollector", "MontferlandNetCollector", "OmrinCollector",
     "RD4Collector", "RecycleApp", "ReinisCollector", "ROVACollector", "StraatbeeldCollector"
 ]

--- a/custom_components/afvalbeheer/collectors/individual/__init__.py
+++ b/custom_components/afvalbeheer/collectors/individual/__init__.py
@@ -2,6 +2,7 @@
 Individual collectors for specific APIs.
 """
 from .afval_alert import AfvalAlertCollector
+from .afvalhulp import AfvalhulpCollector
 from .afvalwijzer import AfvalwijzerCollector
 from .amsterdam import AmsterdamCollector
 from .circulus import CirculusCollector
@@ -18,7 +19,7 @@ from .rova import ROVACollector
 from .straatbeeld import StraatbeeldCollector
 
 __all__ = [
-    "AfvalAlertCollector", "AfvalwijzerCollector", "AmsterdamCollector", "CirculusCollector", "CleanprofsCollector",
+    "AfvalAlertCollector", "AfvalhulpCollector", "AfvalwijzerCollector", "AmsterdamCollector", "CirculusCollector", "CleanprofsCollector",
     "DeAfvalAppCollector", "LimburgNetCollector", "IradoCollector", "MontferlandNetCollector", "OmrinCollector",
     "RD4Collector", "RecycleApp", "ReinisCollector", "ROVACollector", "StraatbeeldCollector"
 ]

--- a/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
+++ b/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
@@ -1,0 +1,176 @@
+"""
+AfvalhulpCollector for waste data from Afvalhulp.nl
+"""
+
+import logging
+from datetime import datetime
+import requests
+import re
+
+from ..base import WasteCollector
+from ...models import WasteCollection
+from ...const import WASTE_TYPE_GREEN, WASTE_TYPE_PAPER, WASTE_TYPE_PMD_GREY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AfvalhulpCollector(WasteCollector):
+    WASTE_TYPE_MAPPING = {
+        "gft": WASTE_TYPE_GREEN,
+        "papier": WASTE_TYPE_PAPER,
+        "pmd+": WASTE_TYPE_PMD_GREY
+    }
+
+    MONTHS = {
+        "januari": 1,
+        "februari": 2,
+        "maart": 3,
+        "april": 4,
+        "mei": 5,
+        "juni": 6,
+        "juli": 7,
+        "augustus": 8,
+        "september": 9,
+        "oktober": 10,
+        "november": 11,
+        "december": 12,
+    }
+
+    def __init__(self, hass, waste_collector, postcode, street_number, suffix, custom_mapping):
+        super().__init__(hass, waste_collector, postcode, street_number, suffix, custom_mapping)
+        self.base_url = "https://mijn.afvalhulp.nl"
+
+    def _get_token(self, html):
+        """
+        Extract CSRF
+        """
+        meta_match = re.search(r'<meta name="csrf-token" content="([^"]+)"', html)
+        if meta_match:
+            return meta_match.group(1)
+
+        input_match = re.search(r'name="_token"\s+value="([^"]+)"', html)
+        if input_match:
+            return input_match.group(1)
+
+        return None
+
+    def _parse_dutch_date(self, raw_date):
+        """
+        Parse date strings
+        """
+        raw_date = raw_date.strip().lower()
+
+        match = re.search(
+            r"(?:maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|zondag)\s+(\d{1,2})\s+([a-z]+)\s+(\d{4})",
+            raw_date,
+        )
+        if not match:
+            raise ValueError(f"Unsupported format: {raw_date}")
+
+        day = int(match.group(1))
+        month_name = match.group(2)
+        year = int(match.group(3))
+
+        month = self.MONTHS.get(month_name)
+        if not month:
+            raise ValueError(f"Unknown month: {month_name}")
+
+        return datetime(year, month, day)
+
+    def _parse_collections(self, html):
+        """
+        Parse upcoming dates from HTML
+        """
+        collections = []
+
+        pattern = re.compile(
+            r'<p class="font-bold">\s*(?P<type>[^<]+?)\s*</p>\s*<p>\s*(?P<date>[^<]+?)\s*</p>',
+            re.IGNORECASE,
+        )
+
+        for match in pattern.finditer(html):
+            raw_type = match.group("type").strip()
+            raw_date = match.group("date").strip()
+
+            waste_type = self.map_waste_type(raw_type.lower())
+            if not waste_type:
+                _LOGGER.debug("Unknown waste type: %s", raw_type)
+                continue
+
+            try:
+                collection = WasteCollection.create(
+                    date=self._parse_dutch_date(raw_date),
+                    waste_type=waste_type,
+                    waste_type_slug=raw_type.lower(),
+                )
+            except ValueError as err:
+                _LOGGER.debug("Could not parse date '%s': %s", raw_date, err)
+                continue
+
+            if collection not in self.collections and collection not in collections:
+                collections.append(collection)
+
+        return collections
+
+    def __get_data(self):
+        """
+        Fetch HTML after POST
+        """
+        session = requests.Session()
+
+        headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Referer": f"{self.base_url}/postcode",
+        }
+
+        form_page = session.get(f"{self.base_url}/postcode", headers=headers, timeout=30)
+        form_page.raise_for_status()
+
+        token = self._get_token(form_page.text)
+        if not token:
+            raise ValueError("Could not find CSRF token")
+
+        payload = {
+            "_token": token,
+            "postcode": self.postcode.replace(" ", "").upper(),
+            "housenumber": str(self.street_number),
+            "addition": self.suffix or "",
+        }
+
+        result = session.post(
+            f"{self.base_url}/postcode",
+            data=payload,
+            headers=headers,
+            timeout=30,
+            allow_redirects=True,
+        )
+        result.raise_for_status()
+
+        return result.text
+
+    async def update(self):
+        """
+        Update waste collection dates
+        """
+        _LOGGER.debug("Updating waste collection dates")
+
+        try:
+            html = await self.hass.async_add_executor_job(self.__get_data)
+            collections = self._parse_collections(html)
+
+            self.collections.remove_all()
+
+            for collection in collections:
+                self.collections.add(collection)
+
+            if not collections:
+                _LOGGER.warning("No waste collection dates found")
+
+            return True
+
+        except requests.exceptions.RequestException as exc:
+            _LOGGER.error("Error occurred while fetching data: %r", exc)
+            return False
+        except Exception as exc:
+            _LOGGER.error("Unexpected error in collector: %r", exc)
+            return False

--- a/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
+++ b/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
@@ -21,21 +21,6 @@ class AfvalhulpCollector(WasteCollector):
         "pmd+": WASTE_TYPE_PMD_GREY
     }
 
-    MONTHS = {
-        "januari": 1,
-        "februari": 2,
-        "maart": 3,
-        "april": 4,
-        "mei": 5,
-        "juni": 6,
-        "juli": 7,
-        "augustus": 8,
-        "september": 9,
-        "oktober": 10,
-        "november": 11,
-        "december": 12,
-    }
-
     def __init__(self, hass, waste_collector, postcode, street_number, suffix, custom_mapping):
         super().__init__(hass, waste_collector, postcode, street_number, suffix, custom_mapping)
         self.base_url = "https://mijn.afvalhulp.nl"
@@ -54,73 +39,85 @@ class AfvalhulpCollector(WasteCollector):
 
         return None
 
-    def _parse_dutch_date(self, raw_date):
+    def _get_ical_url(self, html):
         """
-        Parse date strings
+        Extract iCal URL
         """
-        raw_date = raw_date.strip().lower()
-
         match = re.search(
-            r"(?:maandag|dinsdag|woensdag|donderdag|vrijdag|zaterdag|zondag)\s+(\d{1,2})\s+([a-z]+)\s+(\d{4})",
-            raw_date,
+            r"https://mijn\.afvalhulp\.nl/api/v1/ical/[a-f0-9-]{36}/calendar\.ics",
+            html,
         )
         if not match:
-            raise ValueError(f"Unsupported format: {raw_date}")
+            raise ValueError("Could not find iCal URL")
+        return match.group(0)
 
-        day = int(match.group(1))
-        month_name = match.group(2)
-        year = int(match.group(3))
-
-        month = self.MONTHS.get(month_name)
-        if not month:
-            raise ValueError(f"Unknown month: {month_name}")
-
-        return datetime(year, month, day)
-
-    def _parse_collections(self, html):
+    def _parse_ical(self, ical_text):
         """
-        Parse upcoming dates from HTML
+        Parse upcoming dates from iCal
         """
+        if not ical_text:
+            return []
+
         collections = []
+        event = {}
+        lines = []
+        for raw_line in ical_text.splitlines():
+            if raw_line.startswith((" ", "\t")) and lines:
+                lines[-1] += raw_line[1:]
+            else:
+                lines.append(raw_line)
 
-        pattern = re.compile(
-            r'<p class="font-bold">\s*(?P<type>[^<]+?)\s*</p>\s*<p>\s*(?P<date>[^<]+?)\s*</p>',
-            re.IGNORECASE,
-        )
-
-        for match in pattern.finditer(html):
-            raw_type = match.group("type").strip()
-            raw_date = match.group("date").strip()
-
-            waste_type = self.map_waste_type(raw_type.lower())
-            if not waste_type:
-                _LOGGER.debug("Unknown waste type: %s", raw_type)
+        for line in lines:
+            if ":" not in line:
                 continue
 
-            try:
-                collection = WasteCollection.create(
-                    date=self._parse_dutch_date(raw_date),
-                    waste_type=waste_type,
-                    waste_type_slug=raw_type.lower(),
-                )
-            except ValueError as err:
-                _LOGGER.debug("Could not parse date '%s': %s", raw_date, err)
-                continue
+            key, value = line.split(":", 1)
+            field = key.split(";", 1)[0].strip().upper()
+            value = value.strip()
 
-            if collection not in self.collections and collection not in collections:
-                collections.append(collection)
+            if field == "BEGIN" and value == "VEVENT":
+                event = {}
+
+            elif field == "SUMMARY":
+                event["summary"] = value
+                event["waste_type"] = self.map_waste_type(value.lower())
+
+            elif field == "DTSTART":
+                date_str = value[:8]
+                if date_str.isdigit() and len(date_str) == 8:
+                    event["date"] = datetime.strptime(date_str, "%Y%m%d")
+                else:
+                    _LOGGER.debug("Unsupported DTSTART format %s", value)
+
+            elif field == "END" and value == "VEVENT":
+                waste_type = event.get("waste_type")
+                date = event.get("date")
+                summary = event.get("summary", "").lower()
+
+                if waste_type and date:
+                    collection = WasteCollection.create(
+                        date=date,
+                        waste_type=waste_type,
+                        waste_type_slug=summary,
+                    )
+                    if collection not in self.collections and collection not in collections:
+                        collections.append(collection)
+                else:
+                    _LOGGER.debug("Incomplete iCal event %s", event)
+
+                event = {}
 
         return collections
 
     def __get_data(self):
         """
-        Fetch HTML after POST
+        Fetch iCal data
         """
         session = requests.Session()
 
         headers = {
             "User-Agent": "Mozilla/5.0",
-            "Referer": f"{self.base_url}/postcode",
+            "Referer": f"{self.base_url}/",
         }
 
         form_page = session.get(f"{self.base_url}/postcode", headers=headers, timeout=30)
@@ -146,7 +143,23 @@ class AfvalhulpCollector(WasteCollector):
         )
         result.raise_for_status()
 
-        return result.text
+        schedule_page = session.get(
+            f"{self.base_url}/pickup-schedule",
+            headers={**headers, "Referer": result.url},
+            timeout=30,
+        )
+        schedule_page.raise_for_status()
+
+        ical_url = self._get_ical_url(schedule_page.text)
+
+        ical_response = session.get(
+            ical_url,
+            headers=headers,
+            timeout=30,
+        )
+        ical_response.raise_for_status()
+
+        return ical_response.text or ""
 
     async def update(self):
         """
@@ -155,8 +168,8 @@ class AfvalhulpCollector(WasteCollector):
         _LOGGER.debug("Updating waste collection dates")
 
         try:
-            html = await self.hass.async_add_executor_job(self.__get_data)
-            collections = self._parse_collections(html)
+            ical_text = await self.hass.async_add_executor_job(self.__get_data)
+            collections = self._parse_ical(ical_text)
 
             self.collections.remove_all()
 

--- a/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
+++ b/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
@@ -4,6 +4,7 @@ AfvalhulpCollector for waste data from Afvalhulp.nl
 
 import logging
 from datetime import datetime
+import asyncio
 import requests
 import re
 
@@ -168,8 +169,18 @@ class AfvalhulpCollector(WasteCollector):
         _LOGGER.debug("Updating waste collection dates")
 
         try:
-            ical_text = await self.hass.async_add_executor_job(self.__get_data)
-            collections = self._parse_ical(ical_text)
+            collections = []
+
+            for attempt in range(2):
+                ical_text = await self.hass.async_add_executor_job(self.__get_data)
+                collections = self._parse_ical(ical_text)
+
+                if collections:
+                    break
+
+                if attempt == 0:
+                    _LOGGER.warning("No waste collection dates found, retrying in 10 seconds")
+                    await asyncio.sleep(10)
 
             self.collections.remove_all()
 
@@ -178,6 +189,7 @@ class AfvalhulpCollector(WasteCollector):
 
             if not collections:
                 _LOGGER.warning("No waste collection dates found")
+                return False
 
             return True
 

--- a/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
+++ b/custom_components/afvalbeheer/collectors/individual/afvalhulp.py
@@ -182,14 +182,14 @@ class AfvalhulpCollector(WasteCollector):
                     _LOGGER.warning("No waste collection dates found, retrying in 10 seconds")
                     await asyncio.sleep(10)
 
+            if not collections:
+                _LOGGER.warning("No waste collection dates found")
+                return False
+
             self.collections.remove_all()
 
             for collection in collections:
                 self.collections.add(collection)
-
-            if not collections:
-                _LOGGER.warning("No waste collection dates found")
-                return False
 
             return True
 

--- a/custom_components/afvalbeheer/config_flow.py
+++ b/custom_components/afvalbeheer/config_flow.py
@@ -18,7 +18,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 WASTE_COLLECTORS = [
-    "ACV", "Afval3xBeter", "Afvalstoffendienstkalender", "AfvalAlert",
+    "ACV", "Afval3xBeter", "Afvalstoffendienstkalender", "AfvalAlert", "Afvalhulp",
     "Almere", "AlphenAanDenRijn", "Amsterdam", "AreaReiniging", "Assen", "Avalex", "Avri", "BAR",
     "Berkelland", "Blink", "Circulus", "Cleanprofs", "Cranendonck",
     "Cyclus", "DAR", "DeAfvalApp", "DeFryskeMarren", "DenHaag", "Drimmelen", "GAD",


### PR DESCRIPTION
Gemeente Terneuzen switched from [DeAfvalApp](https://www.deafvalapp.nl/) to [Afvalhulp](https://mijn.afvalhulp.nl/). They don't seem to provide an API, so this collector gets a CSRF token, does a POST, and gets the waste collection days from the HTML.

I made mappings for gft, papier & pmd+ only as there are no other waste types in Gemeente Terneuzen. I'm not sure if there are other municipalities using Afvalhulp so far.