### PR TITLE
Fix waste type notification reset

### DIFF
--- a/custom_components/afvalbeheer/API.py
+++ b/custom_components/afvalbeheer/API.py
@@ -106,7 +106,7 @@ class WasteData(object):
                 f'Waste type slugs used by API: {", ".join(self.collector.collections.get_available_waste_type_slugs())}',
                 f'Afvalwijzer {self.waste_collector}',
                 f'{NOTIFICATION_ID}_availablewastetypeslugs_{self.waste_collector}')
-            self.print_waste_type = False
+            self.print_waste_type_slugs = False
 
     @property
     def collections(self):


### PR DESCRIPTION
Fixes the printwastetypeslugs option resetting the wrong internal flag after creating the notification.

Previously it reset print_waste_type instead of print_waste_type_slugs so the notification could be recreated on every update.