### PR TITLE
Avoid mutating date format while formatting state

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -185,9 +185,10 @@ class BaseSensor(RestoreEntity, SensorEntity):
                 if self.day_of_week_only:
                     formatted = collection_date.strftime("%A")
                 else:
-                    if "%A" not in self.date_format:
-                        self.date_format = "%A, " + self.date_format
-                    formatted = collection_date.strftime(self.date_format)
+                    date_format = self.date_format
+                    if "%A" not in date_format:
+                        date_format = "%A, " + date_format
+                    formatted = collection_date.strftime(date_format)
             else:
                 formatted = collection_date.strftime(self.date_format)
         elif date_diff == 1:


### PR DESCRIPTION
Avoids mutating `self.date_format` while formatting sensor states.


 `_format_date()` prepended `%A` directly to `self.date_format`, so formatting one state could permanently change the configured date format for later updates. This could make sensors keep showing day names even when they should only be shown conditionally.

The method now uses a local `date_format` variable instead.
