### PR TITLE
Fix RecycleApp timestamp parsing

### DIFF
--- a/custom_components/afvalbeheer/collectors/individual/recycle_app.py
+++ b/custom_components/afvalbeheer/collectors/individual/recycle_app.py
@@ -202,7 +202,7 @@ class RecycleApp(WasteCollector):
                     continue
 
                 collection = WasteCollection.create(
-                    date=datetime.strptime(item['timestamp'], '%Y-%m-%dT%H:%M:%S.000Z'),
+                    date=datetime.fromisoformat(item['timestamp'].replace('Z', '+00:00')).replace(tzinfo=None),
                     waste_type=waste_type,
                     waste_type_slug=item['fraction']['name']['nl']
                 )


### PR DESCRIPTION
## Summary

Fixes RecycleApp timestamp parsing so API timestamps with fractional seconds are handled correctly.

## Problem

The previous parser expected timestamps in this exact format:

```text
%Y-%m-%dT%H:%M:%S.000Z