### PR TITLE
Avoid logging sensitive sensor configuration

### DIFF
--- a/custom_components/afvalbeheer/sensor.py
+++ b/custom_components/afvalbeheer/sensor.py
@@ -58,7 +58,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     _LOGGER.debug("Schedule update: %s", schedule_update)
 
     config_data = discovery_info["config"] if discovery_info and "config" in discovery_info else config
-    _LOGGER.debug("Configuration data: %s", config_data)
+    _LOGGER.debug(
+        "Resolved config for waste collector: %s, resources: %s",
+        config_data.get(CONF_WASTE_COLLECTOR),
+        config_data.get(CONF_RESOURCES),
+    )
 
     await async_prepare_translations(hass, resolve_language(config_data))
 
@@ -131,7 +135,6 @@ class BaseSensor(RestoreEntity, SensorEntity):
         self._entity_picture = None
         self._attr_unique_id = None
         self._config = config
-        _LOGGER.debug("BaseSensor initialized with configuration: %s", config)
 
     @property
     def state(self):


### PR DESCRIPTION
## Summary

Avoid logging the full sensor configuration dictionary, which may contain sensitive or personal data.

## Changes

- Replace the full setup config dump with a minimal debug log containing only:
  - waste collector
  - resolved resources
- Remove the redundant per-entity `BaseSensor` config dump.

## Why

The previous debug logs could expose values such as email, password, postcode, street number, suffix, customer ID, or address ID when debug logging was enabled.

The replacement keeps useful setup diagnostics without logging sensitive configuration data.