### PR TITLE
Handle missing Circulus API response

### DIFF
--- a/custom_components/afvalbeheer/collectors/individual/circulus.py
+++ b/custom_components/afvalbeheer/collectors/individual/circulus.py
@@ -101,6 +101,9 @@ class CirculusCollector(WasteCollector):
 
         try:
             r = await self.hass.async_add_executor_job(self.__get_data)
+            if r is None:
+                _LOGGER.error('No response received from Circulus API!')
+                return
             response = r.json()
 
             if not response or 'customData' not in response or not response['customData']['response']['garbage']:


### PR DESCRIPTION
## Summary

Prevent the Circulus collector from crashing when no API response is returned.

## Problem

`CirculusCollector.__get_data()` can return `None` when session or login cookies cannot be obtained.

`update()` previously called `.json()` unconditionally, causing:

`AttributeError: 'NoneType' object has no attribute 'json'`

## Fix

Add a small guard before parsing the response.

If no response is available, the collector now logs the failure and exits the update cleanly.