### PR TITLE
Handle invalid Circulus session cookie format

### DIFF
--- a/custom_components/afvalbeheer/collectors/individual/circulus.py
+++ b/custom_components/afvalbeheer/collectors/individual/circulus.py
@@ -49,7 +49,11 @@ class CirculusCollector(WasteCollector):
                 session_cookie = item[1]
 
         if session_cookie:
-            authenticityToken = re.search('__AT=(.*)&___TS=', session_cookie).group(1)
+            authenticityToken_match = re.search('__AT=(.*)&___TS=', session_cookie)
+            if not authenticityToken_match:
+                _LOGGER.error("Unable to parse authenticity token from Session Cookie")
+                return
+            authenticityToken = authenticityToken_match.group(1)
             data = {
                 'authenticityToken': authenticityToken,
                 'zipCode': self.postcode,


### PR DESCRIPTION
## Summary

Prevent the Circulus collector from crashing when the expected authenticity token is missing from the session cookie.

## Problem

The collector previously called `.group(1)` directly on the result of `re.search()`.

If the Circulus sessioncookie format changes or the expected token is missing, `re.search()` returns `None`, causing an `AttributeError`.

## Fix

Check the regex match before accessing the captured token.

If the token cannot be parsed, the collector now logs the issue and exits the request flow cleanly.