### PR TITLE
Remove unused Python dependencies

### DIFF
--- a/custom_components/afvalbeheer/manifest.json
+++ b/custom_components/afvalbeheer/manifest.json
@@ -4,10 +4,7 @@
   "documentation": "https://github.com/pippyn/Home-Assistant-Sensor-Afvalbeheer",
   "dependencies": [],
   "codeowners": ["@pippyn"],
-  "requirements": [
-    "rsa",
-    "pycryptodome"
-  ],
+  "requirements": [],
   "version": "6.5.21",
   "config_flow": true
 }


### PR DESCRIPTION
## Summary

Remove the unused `rsa` and `pycryptodome` Python dependencies from the integration manifest.