### PR TITLE
Recover from rejected Burgerportaal refresh token

### DIFF
--- a/custom_components/afvalbeheer/collectors/shared/burgerportaal.py
+++ b/custom_components/afvalbeheer/collectors/shared/burgerportaal.py
@@ -77,8 +77,9 @@ class BurgerportaalCollector(WasteCollector):
         }
 
         response = requests.post("https://securetoken.googleapis.com/v1/token?key={}".format(self.apikey), headers=headers, data=data).json()
-        if not response:
-            _LOGGER.error('Unable to fetch ID token!')
+        if not response or 'id_token' not in response:
+            _LOGGER.warning('Stored refresh token was rejected, obtaining new credentials')
+            self.__fetch_refresh_token()
             return
         self.id_token = response['id_token']
         self._auth_changed = True


### PR DESCRIPTION
## Summary

Allow the Burgerportaal collector to recover when a stored refresh token is rejected.

## Problem

The collector assumed that the Firebase token endpoint would always return an `id_token`.

When a refresh token expires or is revoked, the endpoint can instead return a valid JSON error response without `id_token`, causing an uncaught `KeyError`.

## Fix

Detect responses that do not contain an `id_token` and fall back to the collector's existing credential acquisition flow.

The newly obtained credentials are then persisted through the existing authentication storage logic.