### PR TITLE
Avoid duplicate Amsterdam API request

### DIFF
--- a/custom_components/afvalbeheer/collectors/individual/amsterdam.py
+++ b/custom_components/afvalbeheer/collectors/individual/amsterdam.py
@@ -72,7 +72,7 @@ class AmsterdamCollector(WasteCollector):
         get_url = f'{self.waste_collector_url}/?{query_string}'
         test_response = requests.get(get_url)
         is_valid = len(test_response.text) > 220
-        return is_valid, get_url
+        return is_valid, test_response
 
     def __init__(self, hass, waste_collector, postcode, street_number, suffix, custom_mapping):
         super().__init__(hass, waste_collector, postcode, street_number, suffix, custom_mapping)
@@ -99,9 +99,9 @@ class AmsterdamCollector(WasteCollector):
         # Try each suffix combination
         for suffix_param in suffix_params:
             params = {**base_params, **suffix_param}
-            test_result, get_url = self.check_response_for_suffix(params)
+            test_result, test_response = self.check_response_for_suffix(params)
             if test_result:
-                return requests.get(get_url)
+                return test_response
         
         # No suffix or all suffix attempts failed - use base parameters
         filtered_params = {k: v for k, v in base_params.items() if v}


### PR DESCRIPTION
## Summary

Avoid an unnecessary duplicate HTTP request in the Amsterdam collector.

## Problem

When testing suffix variants, the collector already fetched the complete API response to determine whether a candidate URL was valid.

If the candidate succeeded, the response was discarded and the exact same URL was requested again immediately afterward.

## Fix

Reuse the successful response that was already fetched during suffix detection.