### PR TITLE
Reschedule updates after collector failure

### DIFF
--- a/custom_components/afvalbeheer/API.py
+++ b/custom_components/afvalbeheer/API.py
@@ -90,11 +90,13 @@ class WasteData(object):
 
     async def async_update(self, *_):
         _LOGGER.debug("Performing async update")
-        await self.collector.update()
-        if self.update_interval is not None and self.update_interval != 0:
-            await self.schedule_update(timedelta(hours=self.update_interval))
-        else:
-            await self.schedule_update(SCHEDULE_UPDATE_INTERVAL)
+        try:
+            await self.collector.update()
+        finally:
+            if self.update_interval is not None and self.update_interval != 0:
+                await self.schedule_update(timedelta(hours=self.update_interval))
+            else:
+                await self.schedule_update(SCHEDULE_UPDATE_INTERVAL)
         if self.print_waste_type:
             persistent_notification.create(
                 self.hass,


### PR DESCRIPTION
## Summary

Ensure the Afvalbeheer polling cycle continues after a collector update fails.

## Problem

`WasteData.async_update()` scheduled the next update only after `collector.update()` completed successfully.

If a collector raised an exception while parsing or fetching data, execution never reached the scheduling code and that polling chain stopped until the integration was reloaded or Home Assistant restarted.

## Fix

Move the existing rescheduling logic into a `finally` block.

The next update is now scheduled whether the current update succeeds or fails, while the original exception still propagates normally.