### PR TITLE
Fix YAML import resource mapping

### DIFF
--- a/custom_components/afvalbeheer/config_flow.py
+++ b/custom_components/afvalbeheer/config_flow.py
@@ -111,6 +111,8 @@ class AfvalbeheerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             from .API import get_wastedata_from_config
             data = get_wastedata_from_config(self.hass, temp_config)
             if data and hasattr(data, 'collections'):
+                # Fetch collector data once (no scheduling) before reading resources
+                await data.collector.update()
                 # Get available resources from API
                 available_resources = data.collections.get_available_waste_types()
                 if available_resources:


### PR DESCRIPTION
## Summary

Fix YAML import resource matching so collector resources are actually fetched before case insensitive mapping is applied.

## Problem

The YAML import flow created a `WasteData` instance and immediately read its available waste types.

At that point the collection repository was still empty, so the resource matching block never ran and the raw YAML resource names were always used.