### PR TITLE
Avoid scheduling updates during resource lookup

### DIFF
--- a/custom_components/afvalbeheer/config_flow.py
+++ b/custom_components/afvalbeheer/config_flow.py
@@ -498,7 +498,7 @@ class AfvalbeheerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.warning("Data object missing collections attribute for %s", address[CONF_WASTE_COLLECTOR])
                 return {"error": "invalid_data", "resources": []}
             
-            await data.async_update()
+            await data.collector.update()
             resources = data.collections.get_available_waste_types()
             if not resources:
                 _LOGGER.warning("No waste types found for %s at %s %s", 


### PR DESCRIPTION
## Summary

Prevent the config flow from creating orphan background polling callbacks when fetching available waste types.

## Problem

`_async_get_available_resources()` used a temporary `WasteData` instance and called `data.async_update()`.

That method not only fetches collector data, but also schedules the next update. Since the temporary object is not retained, this could leave an orphan polling chain running in the background.