### PR TITLE
Handle empty Limburg.NET address lookup results

### DIFF
--- a/custom_components/afvalbeheer/collectors/individual/limburg_net.py
+++ b/custom_components/afvalbeheer/collectors/individual/limburg_net.py
@@ -53,7 +53,7 @@ class LimburgNetCollector(WasteCollector):
         response = requests.get('{}/afval-kalender/gemeenten/search?query={}'.format(
             self.main_url, self.city_name)).json()
 
-        if not response[0]['nisCode']:
+        if not response or not response[0].get('nisCode'):
             _LOGGER.error('City not found!')
             return
 
@@ -62,7 +62,7 @@ class LimburgNetCollector(WasteCollector):
         response = requests.get('{}/afval-kalender/gemeente/{}/straten/search?query={}'.format(
             self.main_url, self.city_id, self.street_name)).json()
 
-        if not response[0]['nummer']:
+        if not response or not response[0].get('nummer'):
             _LOGGER.error('Street not found!')
             return
 


### PR DESCRIPTION
## Summary

Prevent the Limburg.NET collector from crashing when municipality or street searches return no results.

## Problem

The collector accessed the first item of the API response directly with `response[0]`.

If Limburg.NET returned an empty list for an unknown or unmatched city/street, this raised `IndexError` instead of following the existing "City not found!" / "Street not found!" error path.

## Fix

Check that the response contains an item before reading `nisCode` or `nummer`.

Missing results now log the existing error message and return cleanly.