### PR TITLE
Fix Limburg.NET address query encoding

### DIFF
--- a/custom_components/afvalbeheer/collectors/individual/limburg_net.py
+++ b/custom_components/afvalbeheer/collectors/individual/limburg_net.py
@@ -43,15 +43,17 @@ class LimburgNetCollector(WasteCollector):
     def __init__(self, hass, waste_collector, postcode, street_number, suffix, custom_mapping, street_name, city_name):
         super().__init__(hass, waste_collector, postcode, street_number, suffix, custom_mapping)
         self.city_name = city_name
-        self.street_name = street_name.replace(" ", "+")
+        self.street_name = street_name
         self.main_url = "https://limburg.net/api-proxy/public"
         self.city_id = None
         self.street_id = None
 
     def __fetch_address(self):
         _LOGGER.debug("Fetching address from Limburg.net")
-        response = requests.get('{}/afval-kalender/gemeenten/search?query={}'.format(
-            self.main_url, self.city_name)).json()
+        response = requests.get(
+            '{}/afval-kalender/gemeenten/search'.format(self.main_url),
+            params={'query': self.city_name}
+        ).json()
 
         if not response[0]['nisCode']:
             _LOGGER.error('City not found!')
@@ -59,8 +61,10 @@ class LimburgNetCollector(WasteCollector):
 
         self.city_id = response[0]["nisCode"]
 
-        response = requests.get('{}/afval-kalender/gemeente/{}/straten/search?query={}'.format(
-            self.main_url, self.city_id, self.street_name)).json()
+        response = requests.get(
+            '{}/afval-kalender/gemeente/{}/straten/search'.format(self.main_url, self.city_id),
+            params={'query': self.street_name}
+        ).json()
 
         if not response[0]['nummer']:
             _LOGGER.error('Street not found!')


### PR DESCRIPTION
## Summary

Fix address search query encoding in the Limburg.NET collector.

## Problem

Municipality and street names were inserted directly into the request URL, with only spaces in street names manually replaced by `+`.

Valid names containing characters such as apostrophes, accents, `&`, `+`, `#`, or `?` could therefore produce malformed or incorrect query strings.

## Fix

Use the `requests` `params` argument for municipality and street searches so query values are encoded correctly.

The existing endpoints and lookup behavior remain unchanged.